### PR TITLE
Match the 55-character URL part case-insensitively

### DIFF
--- a/gen-cask.js
+++ b/gen-cask.js
@@ -67,7 +67,7 @@ async function generateCask() {
   let firstOS = true;
   let oldestOS;
   for (const { os, url, sha256 } of packages) {
-    const urlParts = url.split(/\/([0-9a-f-]{55})\//);
+    const urlParts = url.split(/\/([0-9a-f-]{55})\//i);
     if (urlParts.length !== 3) {
       throw new Error(`Expecting URL with 55-char ID but got ${url}`);
     }


### PR DESCRIPTION
The URLs now have uppercase A-F instead of a-f as before. Accept either.